### PR TITLE
Added regexp

### DIFF
--- a/lib/replay/catalog.coffee
+++ b/lib/replay/catalog.coffee
@@ -92,10 +92,15 @@ class Catalog
     parse_request = (request)->
       assert request, "#{filename} missing request section"
       [method_and_path, header_lines...] = request.split(/\n/)
-      [method, path] = method_and_path.split(/\s/)
-      assert method && path, "#{filename}: first line must be <method> <path>"
+      if /\sREGEXP\s/.test(method_and_path)
+        [method, raw_regexp] = method_and_path.split(" REGEXP ")
+        [_, in_regexp, flags] = raw_regexp.match(/^\/(.+)\/(i|m|g)?$/)
+        regexp = new RegExp(in_regexp, flags || "")
+      else
+        [method, path] = method_and_path.split(/\s/)
+      assert method && (path || regexp), "#{filename}: first line must be <method> <path>"
       headers = parseHeaders(filename, header_lines, REQUEST_HEADERS)
-      return { url: path, method: method, headers: headers }
+      return { url: path || regexp, method: method, headers: headers }
 
 
     parse_response = (response, body)->

--- a/spec/fixtures/example.com:3002/regexp
+++ b/spec/fixtures/example.com:3002/regexp
@@ -1,0 +1,6 @@
+GET REGEXP /\/regexp/
+
+200 HTTP/1.1
+Content-Type: text/html
+
+regexp

--- a/spec/fixtures/example.com:3002/regexpi
+++ b/spec/fixtures/example.com:3002/regexpi
@@ -1,0 +1,6 @@
+GET REGEXP /\/Aregexp\d/i
+
+200 HTTP/1.1
+Content-Type: text/html
+
+Aregexp2

--- a/spec/replay_spec.coffee
+++ b/spec/replay_spec.coffee
@@ -44,6 +44,38 @@ vows.describe("Replay").addBatch
         assert.deepEqual response.trailers, { }
 
 
+  "matching a regexp url":
+    topic: ->
+      Replay.mode = "replay"
+      request = HTTP.get(hostname: "example.com", port: 3002, method: "post", path: "/regexp", (response)=>
+        response.body = ""
+        response.on "data", (chunk)->
+          response.body += chunk
+        response.on "end", =>
+          @callback null, response
+        request.on "error", @callback
+      )
+      return
+    "should match the right fixture": (error, response)->
+      assert.equal response.body, "regexp"
+
+
+  "matching a regexp url with flags":
+    topic: ->
+      Replay.mode = "replay"
+      request = HTTP.get(hostname: "example.com", port: 3002, method: "post", path: "/aregexp2", (response)=>
+        response.body = ""
+        response.on "data", (chunk)->
+          response.body += chunk
+        response.on "end", =>
+          @callback null, response
+        request.on "error", @callback
+      )
+      return
+    "should match a fixture": (error, response)->
+      assert.equal response.body, "Aregexp2"
+
+
   # Send responses to non-existent server on port 3002. No matching fixture for that path, expect a 404.
   "undefined path":
     topic: ->


### PR DESCRIPTION
Added regexp support for paths in fixtures.

Basically, the syntax goes as follow:

`GET REGEXP /\/some\/path/i`

I believe you'll want me to change the syntax, I think this is the right place to discuss this.
