### PR TITLE
Include Authorization Header in Catalog

### DIFF
--- a/lib/replay/catalog.coffee
+++ b/lib/replay/catalog.coffee
@@ -19,7 +19,7 @@ mkdir = (pathname, callback)->
 
 
 # Only these request headers are stored in the catalog.
-REQUEST_HEADERS = [/^accept/, /^content-type/, /^host/, /^if-/, /^x-/]
+REQUEST_HEADERS = [/^accept/, /^authorization/, /^content-type/, /^host/, /^if-/, /^x-/]
 
 
 class Catalog


### PR DESCRIPTION
So that fixtures can be used that hit the same URL with different authorization values.
