### PR TITLE
Add ability to match based on request body

### DIFF
--- a/lib/replay/catalog.coffee
+++ b/lib/replay/catalog.coffee
@@ -19,7 +19,7 @@ mkdir = (pathname, callback)->
 
 
 # Only these request headers are stored in the catalog.
-REQUEST_HEADERS = [/^accept/, /^authorization/, /^content-type/, /^host/, /^if-/, /^x-/]
+REQUEST_HEADERS = [/^accept/, /^authorization/, /^content-type/, /^host/, /^if-/, /^x-/, /^body/]
 
 
 class Catalog
@@ -28,7 +28,7 @@ class Catalog
     @matchers = {}
 
   find: (host)->
-    # Return result from cache.  
+    # Return result from cache.
     matchers = @matchers[host]
     if matchers
       return matchers
@@ -48,14 +48,14 @@ class Catalog
       matchers = @matchers[host] ||= []
       mapping = @_read(pathname)
       matchers.push Matcher.fromMapping(host, mapping)
-    
+
     return matchers
 
   save: (host, request, response, callback)->
     matcher = Matcher.fromMapping(host, request: request, response: response)
     matchers = @matchers[host] ||= []
     matchers.push matcher
- 
+
     uid = +new Date
     tmpfile = "/tmp/node-replay.#{uid}"
     pathname = "#{@basedir}/#{host}"
@@ -123,7 +123,7 @@ parseHeaders = (filename, header_lines, only = null)->
     continue if line == ""
     [_, name, value] = line.match(/^(.*?)\:\s+(.*)$/)
     continue if only && !match(name, only)
-    
+
     key = (name || "").toLowerCase()
     value = (value || "").trim().replace(/^"(.*)"$/, "$1")
     if Array.isArray(headers[key])

--- a/lib/replay/proxy.coffee
+++ b/lib/replay/proxy.coffee
@@ -28,7 +28,6 @@ HTTP    = require("http")
 Stream  = require("stream")
 URL     = require("url")
 
-
 # HTTP client request that captures the request and sends it down the processing chain.
 class ProxyRequest extends HTTP.ClientRequest
   constructor: (options = {}, @proxy)->
@@ -66,6 +65,7 @@ class ProxyRequest extends HTTP.ClientRequest
     return
 
   write: (chunk, encoding)->
+
     assert !@ended, "Already called end"
     @body ||= []
     @body.push [chunk, encoding]
@@ -76,6 +76,9 @@ class ProxyRequest extends HTTP.ClientRequest
     if data
       @write data, encoding
     @ended = true
+
+    # convert the body to a string instead of nested array
+    @body = @body.map(([chunk, encoding]) -> chunk).join("")
 
     @proxy this, (error, captured)=>
       process.nextTick =>

--- a/lib/replay/recorder.coffee
+++ b/lib/replay/recorder.coffee
@@ -29,7 +29,7 @@ recorded = (settings)->
         catalog.save host, request, response, (error)->
           callback error, response
       return
-   
+
     # Not in recording mode, pass control to the next proxy.
     callback null
 

--- a/test/fixtures/example.com:3002/post_body
+++ b/test/fixtures/example.com:3002/post_body
@@ -1,0 +1,9 @@
+POST /post-body
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 7
+body: foo=bar
+
+201 HTTP/1.1
+Content-Type: text/html
+Date:         Tue, 29 Nov 2011 03:12:15 GMT
+Location:     /posts/1

--- a/test/replay_test.coffee
+++ b/test/replay_test.coffee
@@ -1,7 +1,7 @@
 { assert, setup, HTTP, HTTPS, Replay } = require("./helpers")
 File    = require("fs")
 Request = require("request")
-
+querystring = require('querystring')
 
 # Test replaying results from fixtures in spec/fixtures.
 describe "Replay", ->
@@ -11,7 +11,7 @@ describe "Replay", ->
   describe "matching URL", ->
     before ->
       Replay.mode = "replay"
-      
+
     describe "listeners", ->
       response = null
 
@@ -166,7 +166,7 @@ describe "Replay", ->
       assert error instanceof Error
       assert.equal error.code, "ECONNREFUSED"
 
-  
+
   # Send responses to non-existent server on port 3002. No matching fixture for that host, expect refused connection.
   describe "undefined host", ->
     error = null
@@ -291,3 +291,46 @@ describe "Replay", ->
       it "should return no response body", ->
         assert !response.body
 
+  describe "POST body", ->
+    statusCode = headers = null
+
+    before ->
+      Replay.mode = "replay"
+
+    describe "matching", ->
+      before (done)->
+        this.timeout(0)
+        body = querystring.stringify({foo: "bar"})
+        request = HTTP.request(hostname: "example.com", port: 3002, method: "post", path: "/post-body")
+        request.setHeader "Content-Type", 'application/x-www-form-urlencoded'
+        request.setHeader "Content-Length", body.length
+        request.on "response", (response)->
+          { statusCode, headers } = response
+          response.on "end", done
+        request.on "error", done
+        request.write(body)
+        request.end()
+
+      it "should return status code", ->
+        assert.equal statusCode, 201
+      it "should return headers", ->
+        assert.equal headers.location, "/posts/1"
+
+    describe "no match", ->
+      error = null
+
+      before (done)->
+        body = querystring.stringify({foo: "baz"})
+        request = HTTP.request(hostname: "example.com", port: 3002, method: "post", path: "/post-body")
+        request.setHeader "Content-Type", 'application/x-www-form-urlencoded'
+        request.setHeader "Content-Length", body.length
+        request.on "response", (response)->
+          response.on "end", done
+        request.on "error", (_)->
+          error = _
+          done()
+        request.write(body)
+        request.end()
+
+      it "should fail to connnect", ->
+        assert error instanceof Error


### PR DESCRIPTION
Adds ability to match based on request body. fixes #6 /cc @davidguttman

Pro: can now match on request body and differentiate between matching
and non-matching bodies.

Cons:
- Uses a fake "Body:" header to specify the body
- Does not yet record bodies automatically
