### PR TITLE
catalog assumes access to /tmp/ directory.

### DIFF
--- a/lib/replay/catalog.coffee
+++ b/lib/replay/catalog.coffee
@@ -60,7 +60,7 @@ class Catalog
     matchers.push matcher
  
     uid = +new Date
-    tmpfile = "/tmp/node-replay.#{uid}"
+    tmpfile = "#{@basedir}/node-replay.#{uid}"
     pathname = "#{@basedir}/#{host}"
     logger = request.replay.logger
     logger.log "Creating #{pathname}"


### PR DESCRIPTION
That directory is not available on c9.io. My guess is that it may not work on windows either.
