### PR TITLE
Fix "Recursive nextTick" warning

### DIFF
--- a/src/replay/proxy.coffee
+++ b/src/replay/proxy.coffee
@@ -29,6 +29,10 @@ HTTP              = require("http")
 Stream            = require("stream")
 URL               = require("url")
 
+if typeof setImmediate is 'function'
+  nextTick = setImmediate
+else
+  nextTick = process.nextTick
 
 # HTTP client request that captures the request and sends it down the processing chain.
 class ProxyRequest extends HTTP.ClientRequest
@@ -123,7 +127,7 @@ class ProxyResponse extends Stream
 
   resume: ->
     @_paused = false
-    process.nextTick =>
+    nextTick =>
       return if @_paused || !@_body
       part = @_body.shift()
       if part


### PR DESCRIPTION
Running a large number of concurrent requests causes a node warning and termination of the process in 0.10+

``` shell
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.

RangeError: Maximum call stack size exceeded
```

This change uses setImmediate, when available, in the proxy module.
