### PR TITLE
Support dynamic switching of fixtures

### DIFF
--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -30,6 +30,11 @@ class Catalog
     # We use this to cache host/host:port mapped to array of matchers.
     @matchers = {}
 
+  setFixturesDir: (dir)->
+    @settings.fixtures = dir;
+    @_basedir = null;
+    @matchers = {}
+
   find: (host)->
     # Return result from cache.
     matchers = @matchers[host]
@@ -71,6 +76,9 @@ class Catalog
     mkdir pathname, (error)->
       return callback error if error
       filename = "#{pathname}/#{uid}"
+      filename += "#{request.method.toUpperCase()}"
+      filename += "#{request.url.path.replace(/\//g, "_")}_"
+      filename += "#{response.status}_#{uid}"
 
       try
         file = File.createWriteStream(tmpfile, encoding: "utf-8")

--- a/src/replay/replay.coffee
+++ b/src/replay/replay.coffee
@@ -96,6 +96,10 @@ class Replay extends EventEmitter
       delete @_ignored[host]
       delete @_localhosts[host]
 
+  # Clears loaded fixtures, and updates to new dir
+  setFixturesDir: (dir)->
+    @catalog.setFixturesDir(dir)
+
   # True if this host is allowed network access.
   isAllowed: (host)->
     return !!@_allowed[host]

--- a/test/fixtures/other-fixtures-dir/example.com-3002/weather_in_94606
+++ b/test/fixtures/other-fixtures-dir/example.com-3002/weather_in_94606
@@ -1,0 +1,7 @@
+GET /weather?c=94606
+
+200 HTTP/1.1
+Content-Type: text/html
+Date:         Tue, 30 Nov 2011 03:12:15 GMT
+
+Sweet and cold

--- a/test/replay_test.coffee
+++ b/test/replay_test.coffee
@@ -93,6 +93,40 @@ describe "Replay", ->
     it "should match a fixture", ->
       assert.equal @body, "Aregexp2"
 
+  describe "matching when changing fixtures dir", ->
+    before ->
+      Replay.mode = "replay"
+
+    it "should match response before switch", (done)->
+      doAsserts = ()=>
+        assert.equal @response.headers.date, "Tue, 29 Nov 2011 03:12:15 GMT"
+        assert.equal @body, "Nice and warm\n"
+        done()
+
+      HTTP.get(hostname: "example.com", port: INACTIVE_PORT, path: "/weather?c=94606", (@response)=>
+        @body = ""
+        @response.on "data", (chunk)=>
+          @body += chunk
+        @response.on "end", doAsserts
+      ).on("error", done)
+
+    it "should match response after switch", (done)->
+      Replay.setFixturesDir("#{__dirname}/fixtures/other-fixtures-dir")
+
+      doAsserts = ()=>
+        assert.equal @response.headers.date, "Tue, 30 Nov 2011 03:12:15 GMT"
+        assert.equal @body, "Sweet and cold\n"
+        done()
+
+      HTTP.get(hostname: "example.com", port: INACTIVE_PORT, path: "/weather?c=94606", (@response)=>
+        @body = ""
+        @response.on "data", (chunk)=>
+          @body += chunk
+        @response.on "end", doAsserts
+      ).on("error", done)
+
+    after ->
+      Replay.setFixturesDir("#{__dirname}/fixtures")
 
   describe "recording multiple of the same header", ->
 


### PR DESCRIPTION
Fixes #16.

Had to both reset the `matchers` cache and `_basedir` in Catalog to get it to reload fixtures.

The tests became a bit tedious, are there any betters ways of accomplishing the same?
