### PR TITLE
Support recording and serving images

### DIFF
--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -130,7 +130,10 @@ class Catalog
 readAndInitialParseFile = (filename)->
   buffer = File.readFileSync filename
   parts = buffer.toString('utf8').split('\n\n')
-  body = new Buffer(buffer.slice(parts[0] + '\n\n' + parts[1] + '\n\n').length)
+  if parts.length > 2
+    body = new Buffer(buffer.slice((parts[0] + '\n\n' + parts[1] + '\n\n').length))
+  else
+    body = ''
   return [parts[0], parts[1], body]
 
 # Parse headers from header_lines.  Optional argument `only` is an array of


### PR DESCRIPTION
We found that replay wrote images correctly in fixtures/ but when serving it would mangle them.

This fix changes the reading of data from fixtures/\* so that it treats data up to the 2nd \n\n as a string and after that it leaves in a raw Buffer.

All tests pass, and replay now serves images.
