### PR TITLE
Fix compatibility with superagent and supertest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules
 lib/**/*.js
+.idea/

--- a/src/replay/pass_through.coffee
+++ b/src/replay/pass_through.coffee
@@ -20,7 +20,7 @@ passThrough = (allow)->
         protocol: request.url.protocol
         hostname: request.url.hostname
         port:     request.url.port
-        path:     request.url.path
+        path:     request.path
         method:   request.method
         headers:  request.headers
 

--- a/src/replay/proxy.coffee
+++ b/src/replay/proxy.coffee
@@ -42,6 +42,7 @@ class ProxyRequest extends HTTP.ClientRequest
     protocol = options.protocol || "http:"
     port = options.port || port || (if protocol == "https:" then 443 else 80)
     @url = URL.parse("#{protocol}//#{host || "localhost"}:#{port}#{options.path || "/"}")
+    @path = @url.path
     @headers = {}
     if options.headers
       for n,v of options.headers


### PR DESCRIPTION
Fix #17
- add `path` to request
- match on `req.path`
