### PR TITLE
Fixing double callback issue on catalog save.

### DIFF
--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -99,7 +99,6 @@ class Catalog
           file.write part
         file.end ->
           File.rename tmpfile, filename, callback
-          callback null
       catch error
         callback error
 


### PR DESCRIPTION
The catalog save callback was called twice, once after File.rename finished
and a line after that. This causes issues when under 'record' mode.
