### PR TITLE
Fix issue where 0 becomes empty string ''

### DIFF
--- a/src/replay/proxy.coffee
+++ b/src/replay/proxy.coffee
@@ -46,7 +46,10 @@ class ProxyRequest extends HTTP.ClientRequest
     @headers = {}
     if options.headers
       for n,v of options.headers
-        @headers[n.toLowerCase()] = v.toString();
+        vStr = ''
+        if v != undefined && v != null
+          vStr = v.toString()
+        @headers[n.toLowerCase()] = vStr
 
   setHeader: (name, value)->
     assert !@ended, "Already called end"


### PR DESCRIPTION
Always converting to a string seems to solve the issue.  I can't imagine why a value for a header would be anything but a number or a string, or rather, I can't imagine what would get passed that wouldn't have toString() that would have failed with the previous code.

Either way, tests pass for this. 

Fixes #39
