### PR TITLE
Bug buffer string length

### DIFF
--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -136,7 +136,7 @@ readAndInitialParseFile = (filename)->
   buffer = File.readFileSync(filename)
   parts = buffer.toString('utf8').split('\n\n')
   if parts.length > 2
-    parts0 = new Buffer(parts[0], 'utf8'),
+    parts0 = new Buffer(parts[0], 'utf8')
     parts1 = new Buffer(parts[1], 'utf8')
     body = buffer.slice(parts0.length + parts1.length + 4)
   return [parts[0], parts[1], body || '']

--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -136,7 +136,9 @@ readAndInitialParseFile = (filename)->
   buffer = File.readFileSync(filename)
   parts = buffer.toString('utf8').split('\n\n')
   if parts.length > 2
-    body = buffer.slice(parts[0].length + parts[1].length + 4)
+    parts0 = new Buffer(parts[0], 'utf8'),
+    parts1 = new Buffer(parts[1], 'utf8')
+    body = buffer.slice(parts0.length + parts1.length + 4)
   return [parts[0], parts[1], body || '']
 
 # Parse headers from header_lines.  Optional argument `only` is an array of


### PR DESCRIPTION
@assaf,

When I was using the node-replay, I run into a problem where the recorded http responses contains special characters which cause its buffer length is different then its converted string length. In my case, it was greater than and equal to sign which will take three spaces instead of one after converting to string. The content-length is fixed on the response header, so my response body has two missing characters at the end. 

In the code the parts has been converted to array of strings, however when assigning the body value, it is using the string length to slice buffer. In this pull request, I've converted the parts from string to buffer and use the buffer length to calculate the response body. This will avoid the case I run into.
