### PR TITLE
Fix SSL requests when not providing an explicit `protocol` option.

### DIFF
--- a/src/replay/index.coffee
+++ b/src/replay/index.coffee
@@ -9,6 +9,13 @@ URL           = require("url")
 httpRequest   = HTTP.request
 httpsRequest  = HTTPS.request
 
+copy = (obj) ->
+  o = {}
+
+  for key of obj
+    o[key] = obj[key]
+
+  return o
 
 # Route HTTP requests to our little helper.
 HTTP.request = (options, callback)->
@@ -49,6 +56,8 @@ HTTPS.request = (options, callback)->
     return httpsRequest(options, callback)
 
   # Proxy request
+  options = copy(options)
+  options.protocol = "https:"
   request = new ProxyRequest(options, Replay.chain.start)
   if callback
     request.once("response", callback)

--- a/test/pass_through_test.coffee
+++ b/test/pass_through_test.coffee
@@ -85,7 +85,6 @@ describe "Pass through", ->
     before (done)->
       options =
         method:   "GET"
-        protocol: "https:"
         hostname: "pass-through"
         port:     HTTPS_PORT
         agent:    false


### PR DESCRIPTION
The mocked `request` method shouldn't require passing a `protocol`, following vanilla `HTTPS.request`.

This should fix #46, I think.