### PR TITLE
Record unzipped reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel": "^5.2.9",
     "babel-eslint": "^3.0.1",
     "body-parser": "^1.12.3",
+    "compression": "^1.6.0",
     "del": "^1.1.1",
     "eslint": "^0.20.0",
     "express": "^4.12.3",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,7 @@
 
 const Express     = require('express');
 const bodyParser  = require('body-parser');
+const compression = require('compression');
 const HTTP        = require('http');
 const HTTPS       = require('https');
 const Replay      = require('../src');
@@ -32,7 +33,14 @@ Replay.silent = true;
 
 // Serve pages from localhost.
 const server = new Express();
+server.use(compression({
+  filter: function(req) {
+    return req.headers['accept-encoding'] != null;
+  },
+  threshold: 1
+}));
 server.use( bodyParser.urlencoded({ extended: false }) );
+
 // Success page.
 server.get('/', function(req, res) {
   res.send('Success!');

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -323,6 +323,59 @@ describe('Replay', function() {
   });
 
 
+  describe('recording gzipped replay', function() {
+    const fixturesDir = `${__dirname}/fixtures/127.0.0.1-${HTTP_PORT}`;
+
+    before(setup);
+
+    before(function() {
+      Replay.mode = 'record';
+      Replay.reset('127.0.0.1');
+    });
+
+    it('should create unzipped fixture for gzipped reply', function(done) {
+      const query = { name: 'Amet', extra: 'consectetur'};
+      const request = function(callback) {
+        Request.get({
+          url:    `http://127.0.0.1:${HTTP_PORT}/query`,
+          qs:     query,
+          headers: {
+            'accept-encoding': 'gzip'
+          },
+          json:   true
+        }, function(error, response, body) {
+          if (error)
+            callback(error);
+          else
+            try {
+              assert.deepEqual(body, query);
+              callback(null, query);
+            } catch (error) {
+              callback(error);
+            }
+        });
+      };
+
+      request(function(error) {
+        if (error)
+          done(error);
+        else {
+          // fixtures should be written now
+          Replay.mode = 'replay';
+          request(done);
+        }
+      });
+    });
+
+    after(function() {
+      for(let file of File.readdirSync(fixturesDir))
+        File.unlinkSync(`${fixturesDir}/${file}`);
+      File.rmdirSync(fixturesDir);
+    });
+
+  });
+
+
   describe('recording multiple of the same header', function() {
     const fixturesDir = `${__dirname}/fixtures/127.0.0.1-${HTTP_PORT}`;
 


### PR DESCRIPTION
The PR changes current behaviour slightly. Since now on the response is piped to unzip stream if `content-encoding` headers present.

closes #70
