### PR TITLE
Update README example to use lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Now write some simple test case:
 ```javascript
 const assert  = require('assert');
 const HTTP    = require('http');
-const Replay  = require('Replay');
+const Replay  = require('replay');
 
 HTTP.get({ hostname: 'www.iheartquotes.com', path: '/api/v1/random' }, function(response) {
   var body = '';


### PR DESCRIPTION
Example will work on Windows or OS X, but Linux will not work with an uppercase package name.

I think this change makes it truly cross-platform :wink: