### PR TITLE
Added support for passing-through client cert and key

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "babel": "^5.2.9",
-    "babel-eslint": "^3.0.1",
+    "babel-eslint": "^6.0.4",
     "body-parser": "^1.12.3",
     "del": "^1.1.1",
     "eslint": "^0.20.0",

--- a/src/pass_through.js
+++ b/src/pass_through.js
@@ -24,7 +24,9 @@ module.exports = function passThrough(passThroughFunction) {
         method:   request.method,
         headers:  request.headers,
         agent:    request.agent,
-        auth:     request.auth
+        auth:     request.auth,
+        key:      request.key,
+        cert:     request.cert
       };
 
       const http = new ClientRequest(options);

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -44,6 +44,8 @@ module.exports = class ProxyRequest extends HTTP.IncomingMessage {
     this.url            = URL.parse(`${protocol}//${host || 'localhost'}:${realPort}${options.path || '/'}`, true);
     this.auth           = options.auth;
     this.agent          = options.agent || (protocol === 'https:' ? HTTPS.globalAgent : HTTP.globalAgent);
+    this.cert           = options.cert;
+    this.key            = options.key;
     this.headers        = {};
     if (options.headers)
       for (let name in options.headers) {


### PR DESCRIPTION
I spent the last two days struggling to get a test using certificates working with `node-replay`.

The following snippet shows where my test was failing:

``` javascript
var options = {
  key: certificate.privateKey,
  cert: certificate.certificate,
  // more stuff
}

var request = https.request(options, function(response) { 
  // getting a 403 with node-replay, but 200 when running the app
});
```

The change in this PR allowed me to fix my test. The test runs with both node `0.10` and `4.4`.

These options are listed here: https://nodejs.org/api/https.html#https_https_request_options_callback (see the last example at the bottom of the page).

Please let me know if I am using the wrong approach. Great library btw! :)
