### PR TITLE
Fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "babel": "^5.2.9",
-    "babel-eslint": "^3.0.1",
+    "babel-eslint": "^6.0.4",
     "body-parser": "^1.12.3",
     "del": "^1.1.1",
     "eslint": "^0.20.0",


### PR DESCRIPTION
Build is currently broken because of this issue: https://github.com/babel/babel-eslint/issues/243

Error is `TypeError: Cannot read property 'visitClass' of undefined`

I updated `babel-eslint` (to latest) then ran `npm install` and `npm test` on both node `0.12` and `4.4`. Looks like the issue is solved.