### PR TITLE
Remove src directory from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 npm-debug.log
 node_modules
-src
 documentup.json
 Makefile


### PR DESCRIPTION
The `src` directory was added to `.npmignore` back when this library was written in CoffeeScript.

Now that it has been re-written in JavaScript, I think we should be able to fetch `src`.

I tried to install this module from my fork, such as:
```json
"devDependencies": {
  "replay": "gzurbach/node-replay"
}
```
I noticed that the `src` directory was missing. This change should fix this issue.