### PR TITLE
Backwards-compatible support for old response status formatting

### DIFF
--- a/test/fixtures/example.com-3002/weather_in_94606_old_status
+++ b/test/fixtures/example.com-3002/weather_in_94606_old_status
@@ -1,0 +1,7 @@
+GET /weather?c=94606&statusLineFormat=old
+
+200 HTTP/1.1 
+Content-Type: text/html
+Date:         Tue, 29 Nov 2011 03:12:15 GMT
+
+Nice and warm

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -48,6 +48,35 @@ describe('Replay', function() {
       });
     });
 
+    describe('Old http status line format', function() {
+      let response;
+
+      before(function(done) {
+        HTTP
+          .get(`http://example.com:${INACTIVE_PORT}/weather?c=94606&statusLineFormat=old`, function(_) {
+            response = _;
+            done();
+          })
+          .on('error', done);
+      });
+
+      it('should return HTTP version', function() {
+        assert.equal(response.httpVersion, '1.1');
+      });
+      it('should return status code', function() {
+        assert.equal(response.statusCode, 200);
+      });
+      it('should return response headers', function() {
+        assert.deepEqual(response.headers, {
+          'content-type': 'text/html',
+          'date':         'Tue, 29 Nov 2011 03:12:15 GMT'
+        });
+      });
+      it('should return response trailers', function() {
+        assert.deepEqual(response.trailers, { });
+      });
+    });
+
 
     describe('callback', function() {
       let response;
@@ -505,7 +534,7 @@ describe('Replay', function() {
           response.on('end', done);
         })
         .on('error', done);
-        request.write(`line1\nline2\nline3`);
+        request.write('line1\nline2\nline3');
         request.end();
       });
 


### PR DESCRIPTION
Some APIs still return the response status line in a format like `200 HTTP/1.1`.
This adds support for the old format while retaining support for the new format. 