### PR TITLE
Fix for request library SSL authorization check

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -161,6 +161,7 @@ class ProxyResponse extends Stream.Readable {
     // Not a documented property, but request seems to use this to look for HTTP parsing errors
     this.connection       = new EventEmitter();
     this._body            = captured.body.slice(0);
+    this.client           = { authorized: true }
   }
 
   _read() {

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -505,7 +505,7 @@ describe('Replay', function() {
           response.on('end', done);
         })
         .on('error', done);
-        request.write(`line1\nline2\nline3`);
+        request.write('line1\nline2\nline3');
         request.end();
       });
 


### PR DESCRIPTION
The request library checks that the client SSL connection is OK https://github.com/request/request/blob/48511186495888a5f0cb15a107325001ac91990e/request.js#L745

Need to stub this