### PR TITLE
Ignore dot files

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -177,7 +177,9 @@ module.exports = class Catalog {
 
     const stat = File.statSync(pathname);
     if (stat.isDirectory()) {
-      const files = File.readdirSync(pathname);
+      let files = File.readdirSync(pathname);
+      // remove dot files from the list
+      files = files.filter(f => !/^\./.test(f));
       for (let file of files) {
         let mapping = this._read(`${pathname}/${file}`);
         newMatchers.push(Matcher.fromMapping(host, mapping));

--- a/src/patch_http_request.js
+++ b/src/patch_http_request.js
@@ -28,3 +28,9 @@ HTTP.request = function(options, callback) {
   return request;
 };
 
+// Patch .get method otherwise it calls original HTTP.request
+HTTP.get = function(options, cb) {
+  const req = HTTP.request(options, cb);
+  req.end();
+  return req;
+}


### PR DESCRIPTION
This PR fixes a bug described in #69.
Issue #137 (dropping a random file inside the fixture folder breaks node-replay) is still there, but if you, @assaf, think that this could be a good opportunity to tackle that issue too just le me know and I can amend this PR.

I've also taken the opportunity to fix another issue: on node 8+, `HTTP.get` calls the original request (not `node-request` patched version), so I've added a code to replace that method as well.