### PR TITLE
add support for matching body with regular expression

### DIFF
--- a/src/matcher.js
+++ b/src/matcher.js
@@ -97,14 +97,17 @@ module.exports = class Matcher {
       if (this.headers[name] !== headers[name])
         return false;
 
-    if (body) {
+    if (this.body && body) {
       let data = '';
       for (let chunks of body)
         data += chunks[0];
       data = jsStringEscape(data);
-      if (this.body && this.body !== data)
-        return false;
+
+      return this.body instanceof RegExp ?
+        this.body.test(data) :
+        this.body === data;
     }
+
     return true;
   }
 

--- a/test/fixtures/example.com-3002/post_body_regexp
+++ b/test/fixtures/example.com-3002/post_body_regexp
@@ -1,0 +1,6 @@
+POST /post-body-regexp
+body: REGEXP /Request Body \d+/i
+
+HTTP/1.1 200 OK
+
+response body

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -650,6 +650,64 @@ describe('Replay', function() {
   });
 
 
+  describe('replaying with POST body regular expression', function() {
+    before(function() {
+      Replay.mode = 'replay';
+    });
+
+    describe('matching', function() {
+      let response;
+
+      before(function(done) {
+        const request = HTTP.request({
+          hostname: 'example.com',
+          port:     INACTIVE_PORT,
+          method:   'post',
+          path:     '/post-body-regexp'
+        }, function(_) {
+          response = _;
+          response.on('end', done);
+        })
+        .on('error', done);
+        request.write('request body 17');
+        request.end();
+      });
+
+      it('should return status code', function() {
+        assert.equal(response.statusCode, 200);
+      });
+    });
+
+    describe('not matching', function() {
+      let error;
+
+      before(function(done) {
+        const request = HTTP.request({
+          hostname: 'example.com',
+          port:     INACTIVE_PORT,
+          method:   'post',
+          path:     '/post-body-regexp'
+        }, function(_) {
+          response = _;
+          response.on('end', done);
+        })
+        .on('error', function(_) {
+          error = _;
+          done();
+        });
+        request.write('request body ABC');
+        request.end();
+      });
+
+      it('should callback with error', function() {
+        assert(error instanceof Error);
+        assert.equal(error.code, 'ECONNREFUSED');
+      });
+    });
+
+  });
+
+
   describe('only specified headers', function() {
     const fixturesDir = `${__dirname}/fixtures/127.0.0.1-${HTTP_PORT}`;
 


### PR DESCRIPTION
syntax is similar to that of the URL regular expression
body needs to start with `REGEXP` keyword followed by javascript regular expression and - optionally -
 flags

for example:

    body: REGEXP /request \d\d/i

would match _Request 17_ and _request 06_