### PR TITLE
Add option to restore default response stream mode to 'paused'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ const MATCH_HEADERS = [ /^accept/, /^authorization/, /^body/, /^content-type/, /
 // fixtures  - Main directory for replay fixtures.
 //
 // mode      - The mode we're running in, see MODES.
+//
+// stream    - The mode we're using for response streams ('flowing' or 'paused').
+//             See: https://nodejs.org/docs/latest-v8.x/api/stream.html#stream_two_modes
+//
 class Replay extends EventEmitter {
 
   constructor(mode) {
@@ -63,6 +67,9 @@ class Replay extends EventEmitter {
     super();
     this.mode   = mode;
     this.chain  = new Chain();
+
+    // Response stream mode
+    this.stream = 'flowing';
 
     // Localhost servers: pass request to localhost
     this._localhosts  = new Set([ 'localhost', '127.0.0.1', '::1' ]);
@@ -152,7 +159,6 @@ class Replay extends EventEmitter {
     // Clears loaded fixtures, and updates to new dir
     this.catalog.setFixturesDir(dir);
   }
-
 }
 
 
@@ -186,4 +192,3 @@ module.exports = replay;
 // These must come last since they need module.exports to exist
 require('./patch_http_request');
 require('./patch_dns_lookup');
-

--- a/src/patch_http_request.js
+++ b/src/patch_http_request.js
@@ -23,7 +23,7 @@ HTTP.request = function(options, callback) {
     return new HTTP.ClientRequest(options, callback);
 
   // Proxy request
-  const request = new ProxyRequest(options, Replay.chain.start);
+  const request = new ProxyRequest(options, Replay.chain.start, Replay.stream === 'paused');
   if (callback)
     request.once('response', callback);
   return request;


### PR DESCRIPTION
This pull-request addresses the issue raised in #139 by adding an option on the `Replay` object to return response streams in the "paused" state, as is [default](https://nodejs.org/docs/latest-v8.x/api/stream.html#stream_two_modes) in the Node `http`library.

If this pull-request is acceptable in principal, I'll add related documentation to the README.