### PR TITLE
Prevent patching native modules multiple times

### DIFF
--- a/src/patch_dns_lookup.js
+++ b/src/patch_dns_lookup.js
@@ -3,15 +3,18 @@
 const DNS    = require('dns');
 const Replay = require('./');
 
+const patchedByReplay = '__patched_by_replay__';
 
-const originalLookup = DNS.lookup;
-DNS.lookup = function(domain, options, callback) {
-  if (typeof domain === 'string' && typeof options === 'object' &&
-      typeof callback === 'function' && Replay.isLocalhost(domain)) {
-    const family = options.family || 4;
-    const ip = (family === 6) ? '::1' : '127.0.0.1';
-    callback(null, ip, family);
-  } else
-    originalLookup(domain, options, callback);
-};
-
+if (!DNS[patchedByReplay]) {
+  DNS[patchedByReplay] = true;
+  const originalLookup = DNS.lookup;
+  DNS.lookup = function(domain, options, callback) {
+    if (typeof domain === 'string' && typeof options === 'object' &&
+        typeof callback === 'function' && Replay.isLocalhost(domain)) {
+      const family = options.family || 4;
+      const ip = (family === 6) ? '::1' : '127.0.0.1';
+      callback(null, ip, family);
+    } else
+      originalLookup(domain, options, callback);
+  };
+}

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -1002,21 +1002,21 @@ describe('Replay', function() {
     }
 
 
-    it("shouldn't patch HTTPS.request twice", function() {
+    it('shouldn\'t patch HTTPS.request twice', function() {
       const patchedRequest = HTTPS.request;
       reload('../src/patch_http_request');
       assert.equal(patchedRequest, HTTPS.request);
       assert.equal(true, HTTPS['__patched_by_replay__']);
     })
 
-    it("shouldn't patch HTTP.request twice", function() {
+    it('shouldn\'t patch HTTP.request twice', function() {
       const patchedRequest = HTTP.request;
       reload('../src/patch_http_request');
       assert.equal(patchedRequest, HTTP.request);
       assert.equal(true, HTTP['__patched_by_replay__']);
     })
 
-    it("shouldn't patch HTTPS.get twice", function() {
+    it('shouldn\'t patch HTTPS.get twice', function() {
       const patchedGet = HTTPS.get;
       reload('../src/patch_http_request');
 
@@ -1024,7 +1024,7 @@ describe('Replay', function() {
       assert.equal(true, HTTPS['__patched_by_replay__']);
     })
 
-    it("shouldn't patch HTTP.get twice", function() {
+    it('shouldn\'t patch HTTP.get twice', function() {
       const patchedGet = HTTP.get;
       reload('../src/patch_http_request');
 
@@ -1032,7 +1032,7 @@ describe('Replay', function() {
       assert.equal(true, HTTP['__patched_by_replay__']);
     });
 
-    it("shouldn't patch DNS.lookup twice", function() {
+    it('shouldn\'t patch DNS.lookup twice', function() {
       const DNS = require('dns');
       const patchedLookup = DNS.lookup;
       reload('../src/patch_dns_lookup');

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -995,5 +995,52 @@ describe('Replay', function() {
 
   });
 
+  describe('monkeypatching', function() {
+    function reload(path) {
+      delete require.cache[require.resolve(path)];
+      require(path);
+    }
+
+
+    it("shouldn't patch HTTPS.request twice", function() {
+      const patchedRequest = HTTPS.request;
+      reload('../src/patch_http_request');
+      assert.equal(patchedRequest, HTTPS.request);
+      assert.equal(true, HTTPS['__patched_by_replay__']);
+    })
+
+    it("shouldn't patch HTTP.request twice", function() {
+      const patchedRequest = HTTP.request;
+      reload('../src/patch_http_request');
+      assert.equal(patchedRequest, HTTP.request);
+      assert.equal(true, HTTP['__patched_by_replay__']);
+    })
+
+    it("shouldn't patch HTTPS.get twice", function() {
+      const patchedGet = HTTPS.get;
+      reload('../src/patch_http_request');
+
+      assert.equal(patchedGet, HTTPS.get);
+      assert.equal(true, HTTPS['__patched_by_replay__']);
+    })
+
+    it("shouldn't patch HTTP.get twice", function() {
+      const patchedGet = HTTP.get;
+      reload('../src/patch_http_request');
+
+      assert.equal(patchedGet, HTTP.get);
+      assert.equal(true, HTTP['__patched_by_replay__']);
+    });
+
+    it("shouldn't patch DNS.lookup twice", function() {
+      const DNS = require('dns');
+      const patchedLookup = DNS.lookup;
+      reload('../src/patch_dns_lookup');
+
+      assert.equal(patchedLookup, DNS.lookup);
+      assert.equal(true, DNS['__patched_by_replay__']);
+    });
+  })
+
 });
 


### PR DESCRIPTION
Avoids memory leaks in Jest caused by monkeypatching native modules.
Using the style of fix described here
(https://chanind.github.io/javascript/2019/10/12/jest-tests-memory-leak.html)
adds a property to indicate that DNS, HTTP, and HTTPS have already been
patched.