### PR TITLE
Support |all| option when shimming DNS.lookup

### DIFF
--- a/src/patch_dns_lookup.js
+++ b/src/patch_dns_lookup.js
@@ -10,7 +10,10 @@ DNS.lookup = function(domain, options, callback) {
       typeof callback === 'function' && Replay.isLocalhost(domain)) {
     const family = options.family || 4;
     const ip = (family === 6) ? '::1' : '127.0.0.1';
-    callback(null, ip, family);
+    if (options.all)
+      callback(null, [ip], family);
+    else
+      callback(null, ip, family);
   } else
     originalLookup(domain, options, callback);
 };


### PR DESCRIPTION
Before, clients attempting an "all" style address lookup,
such as the SQL Server database module tedious does in its connector.js
when provided a hostname,
were liable to error out due to treating the argument as an array
when Replay was supplying a string. This might have looked like:

    TypeError: this.addresses.shift is not a function

Now, when the |all| option is detected, the string is wrapped in an
array to match client expectations.