### PR TITLE
move babel-runtime (and core-js) out of deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "postpublish": "gulp tag"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "debug": "^4.0.1",
     "js-string-escape": "^1.0.1"
   },
@@ -38,6 +37,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
+    "babel-runtime": "^6.26.0",
     "body-parser": "^1.18.3",
     "compression": "^1.7.3",
     "del": "^3.0.0",


### PR DESCRIPTION
babel-runtime isnt used in the source code, move it to dev deps 
so that consumers of this lib dont need to install it if they arent using it

Before we have a note about core-js in our install

```
 npm install
...
> core-js@2.6.9 postinstall /Users/gchiodo/fielddbhome/AuthenticationWebService/node_modules/core-js
> node scripts/postinstall || echo "ignore"

Thank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!

The project needs your help! Please consider supporting of core-js on Open Collective or Patreon:
> https://opencollective.com/core-js
> https://www.patreon.com/zloirock

Also, the author of core-js ( https://github.com/zloirock ) is looking for a good job -)

added 583 packages from 1121 contributors and audited 589 packages in 34.215s
```

After we wont:

```
```